### PR TITLE
Update infrastructure workspace in TFC to include common variable set

### DIFF
--- a/bootstrap/infrastructure.tf
+++ b/bootstrap/infrastructure.tf
@@ -17,6 +17,11 @@ resource "tfe_workspace" "infrastructure" {
   }
 }
 
+resource "tfe_workspace_variable_set" "infrastructure_common" {
+  workspace_id    = tfe_workspace.infrastructure.id
+  variable_set_id = tfe_variable_set.common.id
+}
+
 resource "tfe_workspace_variable_set" "infrastructure_hcp" {
   workspace_id    = tfe_workspace.infrastructure.id
   variable_set_id = tfe_variable_set.hcp.id


### PR DESCRIPTION
Apply the `common` variable set in TFC to the `infrastructure` workspace to access the `tfc_organization` and `client_cidr_block` variables.